### PR TITLE
media: Add support for up to level 6.2 for AVC

### DIFF
--- a/media/libstagefright/ACodec.cpp
+++ b/media/libstagefright/ACodec.cpp
@@ -4243,6 +4243,9 @@ int /* OMX_VIDEO_AVCLEVELTYPE */ ACodec::getAVCLevelFor(
         {  589824, 22080, 420, 135000, OMX_VIDEO_AVCLevel5  },
         {  983040, 36864, 543, 240000, OMX_VIDEO_AVCLevel51 },
         { 2073600, 36864, 543, 240000, OMX_VIDEO_AVCLevel52 },
+        { 4177920, 139264, 543, 240000, OMX_VIDEO_AVCLevel6  },
+        { 8355840, 139264, 543, 480000, OMX_VIDEO_AVCLevel61 },
+        { 16711680, 139264, 543, 800000, OMX_VIDEO_AVCLevel62 },
     };
 
     for (size_t i = 0; i < ARRAY_SIZE(limits); i++) {

--- a/media/libstagefright/Utils.cpp
+++ b/media/libstagefright/Utils.cpp
@@ -190,6 +190,9 @@ static void parseAvcProfileLevelFromAvcc(const uint8_t *ptr, size_t size, sp<AMe
         { 50, OMX_VIDEO_AVCLevel5  },
         { 51, OMX_VIDEO_AVCLevel51 },
         { 52, OMX_VIDEO_AVCLevel52 },
+        { 60, OMX_VIDEO_AVCLevel6  },
+        { 61, OMX_VIDEO_AVCLevel61 },
+        { 62, OMX_VIDEO_AVCLevel62 },
     };
     const static ALookup<uint8_t, OMX_VIDEO_AVCPROFILETYPE> profiles {
         { 66, OMX_VIDEO_AVCProfileBaseline },

--- a/media/libstagefright/include/media/stagefright/MediaCodecConstants.h
+++ b/media/libstagefright/include/media/stagefright/MediaCodecConstants.h
@@ -48,6 +48,9 @@ constexpr int32_t AVCLevel42      = 0x2000;
 constexpr int32_t AVCLevel5       = 0x4000;
 constexpr int32_t AVCLevel51      = 0x8000;
 constexpr int32_t AVCLevel52      = 0x10000;
+constexpr int32_t AVCLevel6       = 0x20000;
+constexpr int32_t AVCLevel61      = 0x40000;
+constexpr int32_t AVCLevel62      = 0x80000;
 
 constexpr int32_t H263ProfileBaseline             = 0x01;
 constexpr int32_t H263ProfileH320Coding           = 0x02;


### PR DESCRIPTION
Currently AVC max level supported in framework is 5.2.
This change adds support for up to level 6.2.

CRs-Fixed: 2306511
Change-Id: Ic31cf2c7963f589ae501e38f4bf8dcc7e3dcbf23